### PR TITLE
Feature: expand capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In your project's Gruntfile, add a section named `waitServer` or `wait-server` t
 grunt.initConfig({
   waitServer: {
     options: {
-      url: 'http://localhost:8080',
+      req: 'http://localhost:8080',
       fail: function () {},
       timeout: 10 * 1000,
       isforce: false,
@@ -38,7 +38,10 @@ grunt.initConfig({
     },
     server: {
       options: {
-        url: 'http://localhost:8080',
+        req: {
+          url: 'http://localhost:8080',
+          method: 'HEAD'
+        },
         fail: function () {},
         timeout: 10 * 1000,
         isforce: false,
@@ -52,11 +55,12 @@ grunt.initConfig({
 
 ### Options
 
-#### options.url  
-Type: `string`  
-Default value: `''`  
+#### options.req
+Type: `string` or an options `object`  
+Default value: `undefined`  
+See [request#options](https://github.com/request/request#requestoptions-callback) for available options.
 
-this options is required.  
+This options is required.
 
 
 #### options.fail  
@@ -98,7 +102,7 @@ grunt.initConfig({
   waitServer: {
     server: {
       options: {
-        url: 'http://localhost:8080'
+        req: 'http://localhost:8080'
       }
     },
   },
@@ -112,7 +116,7 @@ grunt.initConfig({
   waitServer: {
     server: {
       options: {
-        url: 'http://localhost:8080',
+        req: 'http://localhost:8080',
         fail: function () {
           console.error('the server had not start'); 
         },

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Default value: `function () {}`
 #### options.timeout  
 Type: `number`  
 Default value: `10 * 1000`  
+*`0` disables the timeout, will wait forever.*
 
 
 #### options.isforce  

--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ Type: `string` or an options `object`
 Default value: `undefined`  
 See [request#options](https://github.com/request/request#requestoptions-callback) for available options.
 
-This options is required.
+#### options.net
+Type: options `object`  
+Default value: `undefined`  
+See [net.connect#options](https://nodejs.org/api/net.html#net_net_connect_options_connectlistener) for available options.
+
+
+**You must supply either `options.req` or `options.net`.**
 
 
 #### options.fail  

--- a/README.md
+++ b/README.md
@@ -36,20 +36,32 @@ grunt.initConfig({
       interval: 800,
       print: true
     },
+
     server: {
       options: {
         req: {
           url: 'http://localhost:8080',
           method: 'HEAD'
-        },
-        fail: function () {},
-        timeout: 10 * 1000,
-        isforce: false,
-        interval: 800,
-        print: true
-      },
+        }
+      }
     },
-  },
+
+    remoteServer: {
+      options: {
+        req: 'http://example.com',
+        print: false
+      }
+    },
+
+    db: {
+      options: {
+        net: {
+          port: 3306
+        },
+        timeout: 0
+      }
+    }
+  }
 });
 ```
 
@@ -66,7 +78,7 @@ Default value: `undefined`
 See [net.connect#options](https://nodejs.org/api/net.html#net_net_connect_options_connectlistener) for available options.
 
 
-**You must supply either `options.req` or `options.net`.**
+##### You must supply either `options.req` or `options.net`.
 
 
 #### options.fail  
@@ -77,7 +89,7 @@ Default value: `function () {}`
 #### options.timeout  
 Type: `number`  
 Default value: `10 * 1000`  
-*`0` disables the timeout, will wait forever.*
+`0` disables the timeout, will wait forever.
 
 
 #### options.isforce  

--- a/tasks/wait_server.js
+++ b/tasks/wait_server.js
@@ -25,9 +25,14 @@ module.exports = function(grunt) {
     var flag = {
       trigger: false
     };
-    var doneTrigger = function () {
+    var doneTrigger = function (timeout) {
       if (!flag.trigger) {
         flag.trigger = true;
+        if (timeout) {
+          grunt.log.warn('timeout.');
+          options.fail();
+          return done(options.isforce);
+        }
         done();
       }
     };
@@ -50,12 +55,7 @@ module.exports = function(grunt) {
     grunt.log.writeln('waiting for server start');
     wait(doneTrigger);
     setTimeout(function () {
-      if (!flag.trigger) {
-        flag.trigger = true;
-        grunt.log.warn('timeout.');
-        options.fail();
-        done(options.isforce);
-      }
+      doneTrigger(true);
     }, options.timeout);
   };
 

--- a/tasks/wait_server.js
+++ b/tasks/wait_server.js
@@ -11,9 +11,9 @@
 var net = require('net');
 var request = require('request');
 
-module.exports = function(grunt) {
+module.exports = function (grunt) {
 
-  var waitServer = function() {
+  var waitServer = function () {
     var taskName = this.nameArgs;
     var options = this.options({
       fail: function () {},
@@ -55,11 +55,11 @@ module.exports = function(grunt) {
           });
         } else if (options.net) {
           // if options.net use net.connect
-          client = net.connect(options.net, function() {
+          client = net.connect(options.net, function () {
             client.destroy();
             done();
           });
-          client.on('error', function() {
+          client.on('error', function () {
             client.destroy();
             setTimeout(tryConnection, options.interval);
           });
@@ -69,9 +69,9 @@ module.exports = function(grunt) {
       tryConnection();
     };
     wait(doneTrigger);
-    setTimeout(function () {
-      doneTrigger(true);
-    }, options.timeout);
+    if (options.timeout > 0) {
+      setTimeout(doneTrigger.bind(null, true), options.timeout);
+    }
   };
 
   grunt.registerMultiTask('wait_server', 'wait for server start', waitServer);

--- a/tasks/wait_server.js
+++ b/tasks/wait_server.js
@@ -14,13 +14,17 @@ module.exports = function(grunt) {
 
   var waitServer = function() {
     var options = this.options({
-      url: '',
       fail: function () {},
       timeout: 10 * 1000,
       isforce: false,
       interval: 800,
       print: true
     });
+
+    if (!options.req) {
+      grunt.fail.fatal('The waitServer task requires the req option\nSee: https://github.com/imyelo/grunt-wait-server#options');
+    }
+
     var done = this.async();
     var flag = {
       trigger: false
@@ -41,7 +45,7 @@ module.exports = function(grunt) {
         if (options.print) {
           console.log('waiting for the server ...');
         }
-        request(options.url, function (err, resp, body) {
+        request(options.req, function (err, resp, body) {
           if (!err) {
             console.log('server is ready.');
             done();

--- a/tasks/wait_server.js
+++ b/tasks/wait_server.js
@@ -8,11 +8,13 @@
 
 'use strict';
 
+var net = require('net');
 var request = require('request');
 
 module.exports = function(grunt) {
 
   var waitServer = function() {
+    var taskName = this.nameArgs;
     var options = this.options({
       fail: function () {},
       timeout: 10 * 1000,
@@ -21,42 +23,51 @@ module.exports = function(grunt) {
       print: true
     });
 
-    if (!options.req) {
-      grunt.fail.fatal('The waitServer task requires the req option\nSee: https://github.com/imyelo/grunt-wait-server#options');
+    if (!options.req && !options.net) {
+      grunt.fail.fatal('The '+ taskName +' task requires the req or net option' +
+        '\nSee: https://github.com/imyelo/grunt-wait-server#options');
     }
 
+    var trigger, client;
     var done = this.async();
-    var flag = {
-      trigger: false
-    };
     var doneTrigger = function (timeout) {
-      if (!flag.trigger) {
-        flag.trigger = true;
+      if (!trigger) {
+        trigger = true;
         if (timeout) {
           grunt.log.warn('timeout.');
           options.fail();
           return done(options.isforce);
         }
+        grunt.log.ok(taskName + ' server is ready.');
         done();
       }
     };
     var wait = function (done) {
-      var doRequest = function () {
+      var tryConnection = function () {
         if (options.print) {
-          console.log('waiting for the server ...');
+          grunt.log.writeln(taskName + ' waiting for the server ...');
         }
-        request(options.req, function (err, resp, body) {
-          if (!err) {
-            console.log('server is ready.');
+        if (options.req) {
+          // if options.req use request
+          request(options.req, function (err, resp, body) {
+            if (!err) { return done(); }
+            setTimeout(tryConnection, options.interval);
+          });
+        } else if (options.net) {
+          // if options.net use net.connect
+          client = net.connect(options.net, function() {
+            client.destroy();
             done();
-          } else {
-            setTimeout(doRequest, options.interval);
-          }
-        });
+          });
+          client.on('error', function() {
+            client.destroy();
+            setTimeout(tryConnection, options.interval);
+          });
+        }
       };
-      doRequest();
+
+      tryConnection();
     };
-    grunt.log.writeln('waiting for server start');
     wait(doneTrigger);
     setTimeout(function () {
       doneTrigger(true);

--- a/tasks/wait_server.js
+++ b/tasks/wait_server.js
@@ -22,6 +22,8 @@ module.exports = function (grunt) {
       interval: 800,
       print: true
     });
+    // check options.url for backwards compatibility
+    if (!options.req && options.url) {options.req = options.url;}
 
     if (!options.req && !options.net) {
       grunt.fail.fatal('The '+ taskName +' task requires the req or net option' +


### PR DESCRIPTION
Hi there, I'd like to offer this PR as a proposed expansion of `grunt-wait-server`'s functionalities.

Changes:
* DRY code base slightly
* Rename `options.url` to `options.req`
* Add backwards compatibility check for `options.url`
* Document `options.req` as a `string` or [request](https://github.com/request/request#requestoptions-callback) options `object`
* Add `options.net` to handle non-http connections
* Document `options.net` as a [net.connect](https://nodejs.org/api/net.html#net_net_connect_options_connectlistener) options `object`
* Add additional usage examples
* Allow timeout to be disabled by setting `options.timeout = 0`

My original use case was that I needed to wait for a database connection to be available, so I added the `net.connect` ability and decided to go from there. Instead of creating a separate module, I figured I would see if these changes would be welcomed here. No worries if this PR is not within the project's scope.

Thanks for your time.